### PR TITLE
Fix the inclusion of the Elm app in the Tauri app

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "beforeBuildCommand": "elm make src/Main.elm --output=out/main.js --optimize",
+    "beforeBuildCommand": "elm make src/Main.elm --output=public/main.js --optimize",
     "beforeDevCommand": "elm make src/Main.elm --output=public/main.js; npx serve public",
     "devPath": "http://localhost:4000",
     "distDir": "../public",


### PR DESCRIPTION
This change fixes the bug that caused the Elm app not to be included in the build, with the result of showing only an empty window in the app.
(The dev tools console showed the 'Elm is not defined' error)

It is the bug described at https://github.com/jxxcarlson/scripta-tauri/issues/1

## Before

![image](https://user-images.githubusercontent.com/19209696/220578884-a890379d-8789-45c6-b5d3-31a1feb3a311.png)

## After

![image](https://user-images.githubusercontent.com/19209696/220578927-d9e41c12-cb86-4a4b-8d28-7dfaeb7ea107.png)
